### PR TITLE
vuetron.io points to some random site.

### DIFF
--- a/src/v2/cookbook/debugging-in-vscode.md
+++ b/src/v2/cookbook/debugging-in-vscode.md
@@ -102,7 +102,7 @@ There are other methods of debugging, varying in complexity. The most popular an
 
 ### Vuetron
 
-[Vuetron](http://vuetron.io/) is a really nice project that extends some of the work that vue-devtools has done. In addition to the normal devtools workflow, you are able to:
+[Vuetron](https://github.com/vuetwo/vuetron) is a really nice project that extends some of the work that vue-devtools has done. In addition to the normal devtools workflow, you are able to:
 
 * Quickly view API Request/Response: if you're using the fetch API for requests, this event is displayed for any request sent. The expanded card displays the request data as well as the response data.
 * Subscribe to specific parts of your application’s state for faster debugging


### PR DESCRIPTION
Changed link from vuetron.io to https://github.com/vuetwo/vuetron